### PR TITLE
PRR-33 bug fix(vercel): add rewrite rules to support SPA routing in production

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
fix(vercel): add `vercel.json` with rewrites for SPA fallback

Ensures client-side routes like /properties/:id work when directly accessed or refreshed on Vercel.