### PR TITLE
PRR-35 add README and commit message guidelines for web app

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,29 @@
+# .gitmessage
+
+# <type>(optional-scope): concise summary in present tense
+#
+# Example:
+# feat(listings): add filter by property type
+# fix(header): correct logo alignment on mobile
+# chore: update Tailwind to v4
+# refactor(utils): simplify slug generation logic
+#
+# Common types:
+# feat     → New feature
+# fix      → Bug fix
+# docs     → Documentation only
+# style    → Formatting, no code change
+# refactor → Code change that doesn't affect behavior
+# perf     → Performance improvements
+# test     → Adding or updating tests
+# chore    → Maintenance, tooling, or dependencies
+# build    → CI/CD or build system changes
+
+<type>(scope): short, imperative summary
+
+# Optional body:
+# - Explain what changed and why
+# - Reference related issues or context
+# - Wrap lines at ~72 characters if long
+
+# BREAKING CHANGE: Describe the breaking change here

--- a/apps/web/COMMIT_GUIDE.md
+++ b/apps/web/COMMIT_GUIDE.md
@@ -1,0 +1,132 @@
+```markdown
+# 📝 Commit Message Guidelines
+
+This repo follows the [Conventional Commits](https://www.conventionalcommits.org/) specification to standardize commit messages and enable automated versioning via `semantic-release`.
+
+All commits **must** follow the format below.
+
+---
+
+## ✨ Format
+
+```bash
+<type>[optional scope]: <short, imperative summary>
+
+[optional body]
+
+[optional footer]
+```
+
+---
+
+## 🔧 Types
+
+Use one of the following types:
+
+| Type        | Purpose                                | Version Impact        |
+|-------------|----------------------------------------|------------------------|
+| `feat`      | A new feature                          | 🚀 Minor version bump  |
+| `fix`       | A bug fix                              | 🛠 Patch version bump  |
+| `chore`     | Maintenance (e.g. deps, configs)       | 🚫 No version bump     |
+| `docs`      | Documentation changes                  | 🚫 No version bump     |
+| `style`     | Code style changes (formatting, etc.)  | 🚫 No version bump     |
+| `refactor`  | Code refactoring (no behavior change)  | 🚫 No version bump     |
+| `perf`      | Performance improvements               | 🚫 No version bump     |
+| `test`      | Adding or updating tests               | 🚫 No version bump     |
+| `build`     | Changes to build tools or CI/CD        | 🚫 No version bump     |
+
+---
+
+## 🔍 Examples
+
+```bash
+feat: add search filters to listings page
+fix: correct image path in property card
+chore: update Tailwind to v4
+docs: add README section on commit standards
+style: format components using Prettier
+refactor(web): simplify listing pagination logic
+```
+
+---
+
+## ⚠️ Breaking Changes
+
+To indicate a breaking change, add `BREAKING CHANGE:` in the commit body or use `!` after the type:
+
+```bash
+feat!: remove support for legacy auth flow
+
+BREAKING CHANGE: Authentication now uses Auth0 only.
+```
+
+> This will trigger a **major** version bump.
+
+---
+
+## 💡 Tips
+
+- Use the **imperative** mood ("add", not "added" or "adds").
+- Keep summaries to **50 characters or less**.
+- Leave an empty line between the subject and body (if body is included).
+- Use the body to explain **why**, not just **what**.
+
+---
+
+## 🚀 Use the `.gitmessage` Template (Optional but Recommended)
+
+1. Create a `.gitmessage` file at the root of your repo with this content:
+
+    ```bash
+    # <type>(optional-scope): short, imperative summary
+
+    # Example:
+    # feat(listings): add filter by property type
+    # fix(header): correct logo alignment on mobile
+    # chore: update Tailwind to v4
+
+    # Types:
+    # feat | fix | chore | docs | style | refactor | perf | test | build
+
+    <type>(scope): your concise message here
+
+    # Optional body:
+    # - What changed and why?
+    # - Any relevant context or links.
+
+    # BREAKING CHANGE: Describe breaking change here
+    ```
+
+2. Configure Git to use this template:
+
+    ```bash
+    git config commit.template .gitmessage
+    ```
+
+3. Then, when committing, run:
+
+    ```bash
+    git commit
+    ```
+
+    Git will open the template in your default text editor for editing.
+
+---
+
+## ✅ Why It Matters
+
+- Enables automated versioning and changelog generation via semantic-release.
+- Improves project history readability.
+- Makes PRs and releases easier to scan and understand.
+
+---
+
+## 📚 Resources
+
+- [Conventional Commits Spec](https://www.conventionalcommits.org/)
+- [semantic-release](https://semantic-release.gitbook.io/semantic-release/)
+- [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+
+---
+
+_This guide is the single source of truth for commit message standards in this repo._

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,54 +1,140 @@
-# React + TypeScript + Vite
+# Planting Roots Realty – Website (`apps/web`)
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This is the main marketing and listings website for Planting Roots Realty, built with React, Vite, Tailwind CSS, and TypeScript. It lives inside the `plantingrootsrealty` monorepo under `apps/web`. It uses `pnpm` as the package manager.
 
-Currently, two official plugins are available:
+Content is sourced from [Sanity](https://www.sanity.io/) via a read-only integration. Sanity is **not included** in this repo — it is managed separately.
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+---
 
-## Expanding the ESLint configuration
+## 📁 Project Structure
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+This folder is part of a larger monorepo. Key structure:
+plantingrootsrealty/
+├── apps/
+│   ├── web/        → This folder (the public-facing website)
+│   └── cms/        → Sanity Studio (managed separately)
+├── packages/       → Shared components/utilities
+└── …
+---
 
-```js
-export default tseslint.config({
-  extends: [
-    // Remove ...tseslint.configs.recommended and replace with this
-    ...tseslint.configs.recommendedTypeChecked,
-    // Alternatively, use this for stricter rules
-    ...tseslint.configs.strictTypeChecked,
-    // Optionally, add this for stylistic rules
-    ...tseslint.configs.stylisticTypeChecked,
-  ],
-  languageOptions: {
-    // other options...
-    parserOptions: {
-      project: ['./tsconfig.node.json', './tsconfig.app.json'],
-      tsconfigRootDir: import.meta.dirname,
-    },
-  },
-})
+## 🛠 Setup & Development
+
+### Install dependencies
+
+From the monorepo root:
+
+```bash
+pnpm install
+### Install dependencies
+
+This installs all dependencies across the monorepo, including shared packages.
+
+### Run development server
+
+```bash
+pnpm dev --filter web
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+Open your browser to [http://localhost:3000](http://localhost:3000) (or the port shown in the console) to view the app.
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+---
 
-export default tseslint.config({
-  plugins: {
-    // Add the react-x and react-dom plugins
-    'react-x': reactX,
-    'react-dom': reactDom,
-  },
-  rules: {
-    // other rules...
-    // Enable its recommended typescript rules
-    ...reactX.configs['recommended-typescript'].rules,
-    ...reactDom.configs.recommended.rules,
-  },
-})
+## Environment Variables
+
+Create an `.env` file in the root of the repo with the following:
+
+```env
+VITE_PUBLIC_SANITY_PROJECT_ID=
+VITE_PUBLIC_SANITY_DATASET=
+VITE_PUBLIC_SANITY_API_VERSION=
+VITE_PUBLIC_SANITY_PREVIEW_TOKEN=
 ```
+
+Replace the placeholders with your actual credentials and URLs.
+These credentials connect the site to the headless Sanity CMS (read-only access).
+
+---
+
+## Git & Deployment
+
+### Save SSH Key Passphrase (Optional)
+
+If your SSH key has a passphrase and you want to avoid entering it every time:
+
+```bash
+# Start SSH agent
+eval "$(ssh-agent -s)"
+
+# Add your SSH key (update the path if necessary)
+ssh-add ~/.ssh/id_ed25519
+```
+
+Add these lines to your shell profile (`~/.zshrc`, `~/.bashrc`, etc.) to automate this on terminal start.
+
+---
+
+### Push Changes to CMS Repository
+
+```bash
+git add .
+git commit -m "Your commit message"
+git push origin main
+```
+
+Verify your remote:
+
+```bash
+git remote -v
+```
+
+If the remote is missing or incorrect, add it with:
+
+```bash
+git remote add origin git@github.com:your-username/your-cms-repo.git
+```
+
+Replace `your-username/your-cms-repo` with your actual GitHub path.
+
+---
+
+## Build & Preview
+
+### Build production-ready files
+
+```bash
+pnpm build
+```
+
+### Preview the production build locally
+
+```bash
+pnpm preview
+```
+
+The `build` command outputs the production assets to the `dist/` folder.
+
+---
+
+## Deployment Notes
+
+- The site is deployed via Vercel, using apps/web as the project root.
+- Configure all required environment variables via Vercel’s dashboard.
+- No Sanity Studio is hosted here — only Sanity integration (via its API).
+- The Cloudflare-managed domain points to Vercel.
+
+
+---
+
+## Additional Tips
+
+- Keep `.env` files out of Git to protect secrets.
+
+- Use `.gitignore` to exclude `node_modules/`, `.env`, and other local files.
+
+- Use pnpm workspaces to manage dependencies across the monorepo.
+- Shared UI components and utilities may live in /packages.
+- For CMS edits or schema changes, use the Sanity Studio project, managed separately.
+
+---
+
+Happy coding! 🚀


### PR DESCRIPTION
This PR adds and updates key documentation for the apps/web directory of the plantingrootsrealty monorepo:

✨ What’s included:
- ✅ New README.md for the web app with:
- Setup and dev instructions
- Build, preview, and deployment notes
- Environment variable guidance
- Git/SSH tips and contribution basics
- ✅ New COMMIT_GUIDELINES.md as the source of truth for commit messages:
- Based on [Conventional Commits](https://www.conventionalcommits.org/)
- Includes formatting rules, example types, and breaking change syntax
- Added .gitmessage template instructions for consistency

💡 Why this matters:
- Establishes clear onboarding for collaborators
- Standardizes commit history for cleaner logs and semantic versioning
- Helps avoid confusion around local dev, deployment setup, and Git usage