### PR TITLE
PRR-39 chore(ci): add GitHub Actions workflow for semantic-release on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,24 +7,23 @@ on:
 
 jobs:
   release:
-    name: Semantic Release
+    name: Release
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
+      - name: ⬇️ Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Node
+      - name: 📦 Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
+          cache: pnpm
 
-      - name: Install dependencies
+      - name: 🧶 Install dependencies
         run: pnpm install
 
-      - name: Run semantic-release
+      - name: 🚀 Run semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: npx semantic-release
+        run: pnpm release


### PR DESCRIPTION
## 📦 What this PR does

This PR sets up an automated release workflow using `semantic-release`. It configures GitHub Actions to trigger on every push to the `main` branch. When a commit with a proper Conventional Commit message is merged, `semantic-release` will:

- Bump the project version
- Generate/update the `CHANGELOG.md`
- Create a new GitHub release

## ✅ Changes

- Added `.github/workflows/release.yml` GitHub Actions workflow
- Configured `semantic-release` to use `GH_TOKEN` stored in GitHub Secrets
- Ensured `release` script is defined in `package.json`

## 🔐 Secrets

This workflow depends on the following GitHub secret:

- `GH_TOKEN`: A Personal Access Token (PAT) with `repo` and `workflow` scopes

Make sure this secret is added under:  
**Repo Settings → Secrets and variables → Actions → Secrets**

## 🧪 Testing

- Verified that the token is accessible via `printenv`
- Dry-run tested `semantic-release` locally with `npx semantic-release --dry-run`
- CI will validate on next merge to `main`

## 🧩 Follow-up

If you're using environments, make sure the secret is mapped to the correct environment.