### PR TITLE
chore: enable Dependabot for weekly dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/" # root for monorepo workspace
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    ignore:
+      - dependency-name: "pnpm" # optional, if you don’t want updates for pnpm itself
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
### Summary:

This PR introduces a .github/dependabot.yml configuration file that enables GitHub Dependabot to automatically check for outdated or insecure dependencies in the monorepo.

---

### What’s included:
- Added .github/dependabot.yml file
- Configured for weekly checks on all npm-based packages via pnpm
- Groups minor and patch updates into a single PR to reduce noise
- Excludes updates for pnpm itself

### Dependabot Configuration:
```
version: 2
updates:
  - package-ecosystem: "npm"
    directory: "/" # Root of the monorepo
    schedule:
      interval: "weekly"
    open-pull-requests-limit: 5
    commit-message:
      prefix: "chore"
      include: "scope"
    ignore:
      - dependency-name: "pnpm"
    groups:
      all-dependencies:
        patterns:
          - "*"
        update-types:
          - "minor"
          - "patch"
```

Why?
- Keeps dependencies up to date
- Automatically opens PRs when updates are available
- Helps reduce technical debt and improve security posture

---

### How to test:
- Go to Insights → Dependency Graph → Dependabot in GitHub
- Confirm that Dependabot is enabled
- After merging, wait for the next scheduled run or manually change the schedule to "daily" to test
