### PR TITLE
chore(ci): add GitHub Actions workflow to automatically manage stale …

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,28 @@
+name: Manage stale issues and pull requests
+
+on:
+  schedule:
+    - cron: '0 0 * * *'   # Runs daily at midnight UTC
+  workflow_dispatch:       # Allows manual triggering
+  issues:
+    types: [opened, reopened]
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v6
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. If you think this is still relevant, please comment or update the issue.'
+          stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity. If you think this is still relevant, please update it.'
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          days-before-stale: 30     # Days of inactivity before marking stale
+          days-before-close: 7      # Days after stale before closing
+          exempt-issue-labels: 'pinned,bug'  # Issues with these labels won't be marked stale
+          exempt-pr-labels: 'do-not-close'   # PRs with these labels won't be marked stale
+          close-issue-message: 'Closing this issue due to inactivity.'
+          close-pr-message: 'Closing this PR due to inactivity.'


### PR DESCRIPTION
### Title:
Add GitHub Actions workflow to manage stale issues and PRs automatically

### Description:
This PR introduces a GitHub Actions workflow that automatically marks inactive issues and pull requests as stale after a period of inactivity and closes them if they remain stale. This helps keep the repository clean, reduces manual triage effort, and improves overall project maintenance.

### Changes:
- Added .github/workflows/stale.yml with configuration for stale bot
- Issues and PRs inactive for 30 days will be marked as stale
- Stale issues and PRs will be closed after 7 days if no activity
- Comments on stale issues or PRs reset the stale timer

### Benefits:
- Automates housekeeping of issues and PRs
- Keeps the issue tracker manageable
- Saves maintainers’ time