### PR TITLE
fix: prr-53 add cors to api to allow both frontend and backend origins

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,8 @@
   "packageManager": "pnpm@10.13.1",
   "dependencies": {
     "@sanity/client": "^7.8.2",
+    "@types/cors": "^2.8.19",
+    "cors": "^2.8.5",
     "express": "^5.1.0",
     "node-fetch": "^3.3.2"
   },

--- a/apps/web/src/lib/cms/hooks/useSanityPages.ts
+++ b/apps/web/src/lib/cms/hooks/useSanityPages.ts
@@ -11,12 +11,14 @@ export function useSanityPage(slug?: string) {
 
     async function fetchPage() {
       try {
+        // Use relative path so it works in dev + prod
         const res = await fetch(`http://localhost:3000/page/${slug}`);
-        if (!res.ok) throw new Error("Failed to fetch page");
+        if (!res.ok) throw new Error(`Failed to fetch page: ${res.status}`);
+
         const data: Page = await res.json();
         if (isMounted) setPage(data);
       } catch (err) {
-        console.error(err);
+        console.error("Error fetching page:", err);
         if (isMounted) setPage(null);
       }
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,12 @@ importers:
       '@sanity/client':
         specifier: ^7.8.2
         version: 7.8.2
+      '@types/cors':
+        specifier: ^2.8.19
+        version: 2.8.19
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.5
       express:
         specifier: ^5.1.0
         version: 5.1.0
@@ -1987,6 +1993,9 @@ packages:
   '@types/conventional-commits-parser@5.0.1':
     resolution: {integrity: sha512-7uz5EHdzz2TqoMfV7ee61Egf5y6NkcO4FB/1iCCQnbeiI1F3xzv3vK5dBCXUCLQgGYS+mUeigK1iKQzvED+QnQ==}
 
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -2665,6 +2674,10 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.5:
+    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
+    engines: {node: '>= 0.10'}
 
   cosmiconfig-typescript-loader@6.1.0:
     resolution: {integrity: sha512-tJ1w35ZRUiM5FeTzT7DtYWAFFv37ZLqSRkGi2oeCK1gPhvaWjkAtfXvLmvE1pRfxxp9aQo6ba/Pvg1dKj05D4g==}
@@ -7634,6 +7647,10 @@ snapshots:
     dependencies:
       '@types/node': 24.2.1
 
+  '@types/cors@2.8.19':
+    dependencies:
+      '@types/node': 24.2.1
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
@@ -8394,6 +8411,11 @@ snapshots:
   cookie@1.0.2: {}
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.5:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cosmiconfig-typescript-loader@6.1.0(@types/node@24.2.1)(cosmiconfig@9.0.0(typescript@5.9.2))(typescript@5.9.2):
     dependencies:


### PR DESCRIPTION
This PR adds CORS support to the API so that the frontend (Vite dev server at http://localhost:5173) can fetch pages without CORS errors.
