### PR TITLE
Fix/backend serve assets production

### DIFF
--- a/apps/api/dist/index.js
+++ b/apps/api/dist/index.js
@@ -26,6 +26,12 @@ app.use(cors({
     methods: ["GET", "POST", "OPTIONS"],
 }));
 app.use(express.json());
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const assetsPath = process.env.VERCEL
+    ? path.join(process.cwd(), 'public', 'assets') // production
+    : path.join(__dirname, '../public/assets'); // local
+app.use('/assets', express.static(assetsPath));
 // -------- PAGE ROUTE --------
 app.get("/page/:slug", async (req, res) => {
     const { slug } = req.params;
@@ -41,10 +47,6 @@ app.get("/page/:slug", async (req, res) => {
         res.status(500).json({ error: "Server error" });
     }
 });
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-// Serve all static assets
-app.use('/assets', express.static(path.join(__dirname, '../public/assets')));
 // -------- LISTINGS ROUTE --------
 app.get("/listings", async (req, res) => {
     try {

--- a/apps/api/index.ts
+++ b/apps/api/index.ts
@@ -31,6 +31,14 @@ app.use(cors({
 
 app.use(express.json())
 
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const assetsPath = process.env.VERCEL
+  ? path.join(process.cwd(), 'public', 'assets')  // production
+  : path.join(__dirname, '../public/assets')     // local
+app.use('/assets', express.static(assetsPath))
+
 // -------- PAGE ROUTE --------
 app.get("/page/:slug", async (req: Request, res: Response) => {
   const { slug } = req.params
@@ -47,12 +55,6 @@ app.get("/page/:slug", async (req: Request, res: Response) => {
     res.status(500).json({ error: "Server error" })
   }
 })
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
-
-// Serve all static assets
-app.use('/assets', express.static(path.join(process.cwd(), '../public/assets')))
 
 // -------- LISTINGS ROUTE --------
 app.get("/listings", async (req: Request, res: Response) => {


### PR DESCRIPTION
This PR updates the backend static assets middleware so that images and other assets are correctly served both in local development and in production on Vercel.

Changes include:
- Added `assetsPath` which uses `__dirname` for local and `process.cwd()` for production.
- Replaced the previous `express.static` path with a production-safe version.
- Ensures frontend URLs like `/assets/logo-contrast.webp` and `/assets/images/...` work in all environments.