### PR TITLE
fix: render only current slide in OurStorySection carousel

### DIFF
--- a/apps/web/src/lib/sections/OurStorySection.tsx
+++ b/apps/web/src/lib/sections/OurStorySection.tsx
@@ -49,8 +49,8 @@ function ModernCarousel({ children, currentSlide, totalSlides, onNext, onPrev, o
             key={index}
             onClick={() => onSlideSelect(index)}
             className={`transition-all duration-300 rounded-full ${index === currentSlide
-                ? 'w-8 h-3 bg-white shadow-lg'
-                : 'w-3 h-3 bg-white/50 hover:bg-white/70'
+              ? 'w-8 h-3 bg-white shadow-lg'
+              : 'w-3 h-3 bg-white/50 hover:bg-white/70'
               }`}
           />
         ))}
@@ -59,7 +59,7 @@ function ModernCarousel({ children, currentSlide, totalSlides, onNext, onPrev, o
   )
 }
 
-export function OurStorySection({  }: { onNavigate: (page: PageType) => void }) {
+export function OurStorySection({ }: { onNavigate: (page: PageType) => void }) {
   const [currentSlide, setCurrentSlide] = useState(0)
   const totalSlides = images.length
 
@@ -98,9 +98,11 @@ export function OurStorySection({  }: { onNavigate: (page: PageType) => void }) 
           onPrev={prevSlide}
           onSlideSelect={setCurrentSlide}
         >
-          {images.map((image, idx) => (
-            <img key={idx} src={image.src} alt={image.alt} className="object-cover w-full h-full" />
-          ))}
+          <img
+            src={images[currentSlide].src}
+            alt={images[currentSlide].alt}
+            className="object-cover w-full h-full"
+          />
         </ModernCarousel>
       </div>
     </div>


### PR DESCRIPTION
### Summary
The OurStorySection carousel was rendering all images simultaneously, so clicking next/previous buttons didn't update the visible slide. This PR fixes the behavior by rendering only the image corresponding to the currentSlide state.

### Changes
- Update ModernCarousel children rendering to show only the current slide.
- Ensure next/prev buttons and slide indicators correctly update the displayed image.

### Testing
- Navigate to the OurStorySection component.
- Click next/prev arrows and verify that only one image is visible at a time and that navigation works correctly.